### PR TITLE
ci: add riscv64 native build on RISE runners

### DIFF
--- a/.github/workflows/alt-arch-riscv64.yml
+++ b/.github/workflows/alt-arch-riscv64.yml
@@ -1,0 +1,37 @@
+name: Alt Arch Riscv64
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build RethinkDB (riscv64)
+    runs-on: ubuntu-24.04-riscv
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential protobuf-compiler python3 \
+            libcurl4-openssl-dev libboost-all-dev libncurses5-dev \
+            libjemalloc-dev libssl-dev
+          sudo ln -sf /usr/bin/python3 /usr/bin/python
+
+      - name: Configure
+        run: ./configure --allow-fetch
+
+      - name: Build
+        run: time make -j$(nproc)
+
+      - name: Verify
+        run: |
+          ./build/release/rethinkdb --version
+          file ./build/release/rethinkdb

--- a/.github/workflows/alt-arch-riscv64.yml
+++ b/.github/workflows/alt-arch-riscv64.yml
@@ -3,10 +3,10 @@ name: Alt Arch Riscv64
 on:
   push:
     branches:
-      - main
+      - next
   pull_request:
     branches:
-      - main
+      - next
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Test PR for RISE runner validation. RethinkDB 2.4.4 builds on native riscv64. Arch support already upstream (commit 4db38a8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added continuous integration support for RISC-V 64 architecture builds to ensure RethinkDB compatibility across additional processor architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->